### PR TITLE
fix(linker): allow `#` in wikilinks

### DIFF
--- a/bot/commands/linker.py
+++ b/bot/commands/linker.py
@@ -4,7 +4,7 @@ from discord.ext import commands
 
 import re
 
-RE_WIKI_LINK_IN_MESSAGE = re.compile(r"\[\[([^\n\[\]#<|{}_�:][^\n\[\]#<|{}_�]*)\]\](?=([^`]|```([^`]|`{1,2}([^`]|$))+```|``([^`]|`([^`]|$))+``|`[^`]+`)*$)")
+RE_WIKI_LINK_IN_MESSAGE = re.compile(r"\[\[([^\n\[\]#<|{}_�:][^\n\[\]<|{}_�]*)\]\](?=([^`]|```([^`]|`{1,2}([^`]|$))```|``([^`]|`([^`]|$))``|`[^`]*`)*$)")
 
 class AutoLinker(commands.Cog):
     """Automatically reply to a message with links to atl.wiki articles if it contains a properly formatted wikilink"""


### PR DESCRIPTION
## Summary by Sourcery

Fix regex in linker cog to allow '#' characters within wikilinks and improve code block lookahead handling

Bug Fixes:
- Allow '#' character in wikilinks
- Refine lookahead regex to correctly handle inline code and code block contexts